### PR TITLE
fix: typo

### DIFF
--- a/tutorial.json
+++ b/tutorial.json
@@ -2530,7 +2530,7 @@
               "2911df4bed99ff46d5a08fbb41ef5f26e7d1f391"
             ]
           },
-          "content": "The confict arose because the first commit you added to this branch changed the same lines as the commit from `main`. So it tried to add the commit, but couldn't because something was already there. There are sections, separated by characters (`<`, `>`, and `=`), that represent the commit you are on (`HEAD`) and the commit that is trying to be added (`feat: add column reference`). Fix the conflict by removing those `<`, `>`, and `=` characters. Then making the JSON object valid again.",
+          "content": "The conflict arose because the first commit you added to this branch changed the same lines as the commit from `main`. So it tried to add the commit, but couldn't because something was already there. There are sections, separated by characters (`<`, `>`, and `=`), that represent the commit you are on (`HEAD`) and the commit that is trying to be added (`feat: add column reference`). Fix the conflict by removing those `<`, `>`, and `=` characters. Then making the JSON object valid again.",
           "hints": [
             "Be sure to remove all those special characters",
             "The part of the JSON object with conflicts should look like this:\n```json\n\"row\": {\n  \"insert\": \"INSERT INTO table_name(columns) VALUES(values);\"\n},\n\"column\": {\n  \"add\": \"ALTER TABLE table_name ADD COLUMN column_name;\"\n}\n```",


### PR DESCRIPTION
fixed the wrong 'confict' typo into 'conflict'

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
fixed the wrong 'confict' typo into 'conflict'