### PR TITLE
Clarify soft vs medium git resets

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -2605,7 +2605,7 @@ View the diff.
 
 ### 1542.1
 
-And the changes from the reset are back in the working tree. So when you `reset` to one commit before `HEAD`, it removed the most recent commit, and put all the changes in the working tree. If you used the `--hard` flag with the reset, the changes would have not been added to the working tree. Add the changes back to staging so you can commit them again.
+And the changes from the reset are back in the working tree. So when you `reset` to one commit before `HEAD`, it removed the most recent commit, and put all the changes in the working tree. If you used the `--hard` flag with the reset, the changes would have not been added to the working tree and if you used the `--soft` flag, the changes would have been added to the working tree and to staging. Add the changes back to staging so you can commit them again.
 
 #### HINTS
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -2570,7 +2570,7 @@ I'm going to show you a few ways to remove or undo a commit. The first is to sim
 
 ### 1536.1
 
-This is a "soft" reset and will put the changes from the commit you undid in your working tree. You can see that it says there's unstaged changes after the reset to your file. View your log with the oneline flag.
+This is a "medium" reset and will put the changes from the commit you undid in your working tree. You can see that it says there's unstaged changes after the reset to your file. View your log with the oneline flag.
 
 #### HINTS
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #48079

<!-- Feel free to add any additional description of changes below this line -->
The first commit corrects the language ("soft" to "medium") and the second explains a `--soft` reset