### PR TITLE
fix: typo in git stash explanation

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1635,7 +1635,7 @@ You can see one item there. Bring the changes back with `git stash pop`.
 
 ### 1050.1
 
-The changes from the stash reappeared in the file and git showed the status for you. You are right where you left of before stashing the changes. Popping a stash like that will remove the most recent stash and apply it to your working tree. View the list of your stashes again.
+The changes from the stash reappeared in the file and git showed the status for you. You are right where you left off before stashing the changes. Popping a stash like that will remove the most recent stash and apply it to your working tree. View the list of your stashes again.
 
 #### HINTS
 

--- a/tutorial.json
+++ b/tutorial.json
@@ -2932,7 +2932,7 @@
               "a99edebbd37ef2c807d344b27a50f59708812faa"
             ]
           },
-          "content": "The changes from the stash reappeared in the file and git showed the status for you. You are right where you left of before stashing the changes. Popping a stash like that will remove the most recent stash and apply it to your working tree. View the list of your stashes again.",
+          "content": "The changes from the stash reappeared in the file and git showed the status for you. You are right where you left off before stashing the changes. Popping a stash like that will remove the most recent stash and apply it to your working tree. View the list of your stashes again.",
           "hints": [
             "Use the \"git stash list\" command in your repo",
             "Type `git stash list` in the terminal and press enter"


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/61320

<!-- Feel free to add any additional description of changes below this line -->

This PR corrects a typo in the Git stash explanation in TUTORIAL.md.
No structural changes were made.
I only fixed a typo in TUTORIAL.md. I did not regenerate tutorial.json by **coderoad build** because it fails validation.